### PR TITLE
Improve Colab Compatibility & Llama Model Selection

### DIFF
--- a/Deepdive-llama3-from-scratch-en.ipynb
+++ b/Deepdive-llama3-from-scratch-en.ipynb
@@ -101,6 +101,123 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If in Google Colab, run this cell to install the required packages\n",
+    "# ! pip install tiktoken blobfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import related libraries\n",
+    "from pathlib import Path  # Used to obtain the file name/model name from the file path\n",
+    "import tiktoken  # An open-source library developed by OpenAI for text encoding and decoding (mutual conversion between text and token IDs)\n",
+    "from tiktoken.load import load_tiktoken_bpe  # Load the BPE model\n",
+    "import torch  # Used for building models and matrix calculations\n",
+    "import json  # Used for loading configuration files\n",
+    "import matplotlib.pyplot as plt  # Used for plotting graphs\n",
+    "from huggingface_hub import login, hf_hub_download  # So that we can download the weights from HuggingFace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Login to HuggingFace so that we can download the weights\n",
+    "login()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "print(f\"Using device: {device}\")\n",
+    "torch.set_default_device(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE: To get the weights from HuggingFace, you need to go to the model's url and request access to the model.\n",
+    "# For example, for model Meta-Llama-3-8B, you need to go to https://huggingface.co/meta-llama/Meta-Llama-3-8B\n",
+    "# and ask to be granted access.\n",
+    "\n",
+    "# Choose any version or flavor of Llama.\n",
+    "# You can choose between versions 3.0, 3.1 or 3.2.\n",
+    "# 3.2 comes in 3B or 1B parameters.\n",
+    "# You can also choose the \"Instruct\" version.\n",
+    "# What's the difference between the \"Instruct\" and the vanilla?\n",
+    "# The \"vanilla\" is the \"Foundational model\" that has not been aligned yet.\n",
+    "# The \"Instruct\" has been aligned and knows how to answer questions.\n",
+    "# It's educational to see that the code is identical, only the weights change.\n",
+    "\n",
+    "# model_path = \"Meta-Llama-3-8B\"             # https://huggingface.co/meta-llama/Meta-Llama-3-8B\n",
+    "\n",
+    "# model_path = \"Llama-3.1-8B\"                # https://huggingface.co/meta-llama/Llama-3.1-8B\n",
+    "\n",
+    "# model_path = \"Llama-3.2-3B\"                # https://huggingface.co/meta-llama/Llama-3.2-3B\n",
+    "model_path = \"Llama-3.2-1B\"                  # https://huggingface.co/meta-llama/Llama-3.2-1B\n",
+    "\n",
+    "# model_path = \"Meta-Llama-3-8B-Instruct\"    # https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct\n",
+    "\n",
+    "# model_path = \"Llama-3.1-8B-Instruct\"       # https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct\n",
+    "\n",
+    "# model_path = \"Llama-3.2-3B-Instruct\"       # https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct\n",
+    "# model_path = \"Llama-3.2-1B-Instruct\"       # https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo_id = f\"meta-llama/{model_path}\"\n",
+    "\n",
+    "files = [\n",
+    "    \"original/consolidated.00.pth\",   # Model weights in PyTorch format\n",
+    "    \"original/params.json\",           # Model configuration\n",
+    "    \"original/tokenizer.model\",       # Tokenizer model\n",
+    "]\n",
+    "\n",
+    "for file in files:\n",
+    "    file_path = hf_hub_download(\n",
+    "        repo_id=repo_id,\n",
+    "        filename=file,\n",
+    "        local_dir=f\"./{model_path}\",\n",
+    "        use_auth_token=True\n",
+    "    )\n",
+    "    print(f\"Downloaded {file} to {file_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# At this point, we need to have these 3 files in the model_path directory:\n",
+    "assert Path(f\"{model_path}/original/tokenizer.model\").exists()\n",
+    "assert Path(f'{model_path}/original/consolidated.00.pth').exists()\n",
+    "assert Path(f\"{model_path}/original/params.json\").exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "ExecutionIndicator": {
      "show": false
@@ -130,16 +247,7 @@
    "source": [
     "# Loading the BPE-based Tokenizer\n",
     "\n",
-    "# Import related libraries\n",
-    "from pathlib import Path  # Used to obtain the file name/model name from the file path\n",
-    "import tiktoken  # An open-source library developed by OpenAI for text encoding and decoding (mutual conversion between text and token IDs)\n",
-    "from tiktoken.load import load_tiktoken_bpe  # Load the BPE model\n",
-    "import torch  # Used for building models and matrix calculations\n",
-    "import json  # Used for loading configuration files\n",
-    "import matplotlib.pyplot as plt  # Used for plotting graphs\n",
-    "\n",
-    "\n",
-    "tokenizer_path = \"Meta-Llama-3-8B/original/tokenizer.model\"  # Path to the tokenizer model\n",
+    "tokenizer_path = f\"{model_path}/original/tokenizer.model\"  # Path to the tokenizer model\n",
     "\n",
     "# Special tokens outside the regular dictionary.\n",
     "# These special tokens are present in the 'added_tokens' field of both 'tokenizer.json' and 'tokenizer_config.json' in the \"Meta-Llama-3-8B/\" path\n",
@@ -285,7 +393,7 @@
    ],
    "source": [
     "# Load the model, a dictionary such as {\"network-layer-name\": tensor-type parameters}\n",
-    "model = torch.load(\"Meta-Llama-3-8B/original/consolidated.00.pth\")\n",
+    "model = torch.load(f\"{model_path}/original/consolidated.00.pth\", weights_only=False, map_location=device)\n",
     "\n",
     "# Print the names of the first 20 network layers to verify if the model is loaded correctly.\n",
     "print(json.dumps(list(model.keys())[:20], indent=4))"
@@ -330,7 +438,7 @@
    "source": [
     "# Load the configuration file.\n",
     "# The specific meaning of each configuration is described in the next section.\n",
-    "with open(\"Meta-Llama-3-8B/original/params.json\", \"r\") as f:\n",
+    "with open(f\"{model_path}/original/params.json\", \"r\") as f:\n",
     "    config = json.load(f)\n",
     "config"
    ]
@@ -1315,7 +1423,8 @@
    "source": [
     "# Calculate θ. Step 1: Obtain i/D.\n",
     "# [64]\n",
-    "zero_to_one_split_into_64_parts = torch.tensor(range(64))/64  # Each feature has 64 dimension pairs after segmentation, so 64 θ values are required\n",
+    "n_split = head_dim // 2\n",
+    "zero_to_one_split_into_64_parts = torch.tensor(range(n_split))/n_split  # Each feature has 64 dimension pairs after segmentation, so 64 θ values are required\n",
     "zero_to_one_split_into_64_parts"
    ]
   },
@@ -1447,6 +1556,7 @@
     "for i, index in enumerate(token_to_show):\n",
     "    value = freqs_cis[index]\n",
     "    for j, element in enumerate(value):\n",
+    "        element = element.cpu()\n",
     "        # Plot a blue line from the origin to the coordinate point, with the real part as the x-coordinate and the imaginary part as the y-coordinate.\n",
     "        axs[i].plot([0, element.real], [0, element.imag], color='blue', linewidth=1, label=f\"Index: {j}\")\n",
     "        # Draw red numerical annotations to represent the i-th pair of dimensions.\n",
@@ -2201,8 +2311,8 @@
     "for head in range(n_heads):\n",
     "    # Extract the QKV weight matrices corresponding to the current head\n",
     "    q_layer0_head = q_layer0[head]  # [32x128x4096] -> [128x4096]\n",
-    "    k_layer0_head = k_layer0[head//4]  # Every 4 heads share one key weight, [8x128x4096] -> [128x4096]\n",
-    "    v_layer0_head = v_layer0[head//4]  # Every 4 heads share one value weight, [8x128x4096] -> [128x4096]\n",
+    "    k_layer0_head = k_layer0[head//(n_heads // n_kv_heads)]  # Every 4 heads share one key weight, [8x128x4096] -> [128x4096]\n",
+    "    v_layer0_head = v_layer0[head//(n_heads // n_kv_heads)]  # Every 4 heads share one value weight, [8x128x4096] -> [128x4096]\n",
     "    \n",
     "    # Calculate XW to obtain the QKV vectors\n",
     "    # [17x4096] x [4096x128] = [17x128]\n",
@@ -2696,8 +2806,8 @@
     "    for head in range(n_heads):\n",
     "        # Extract the QKV weight matrices corresponding to the current head\n",
     "        q_layer_head = q_layer[head]  # [32x128x4096] -> [128x4096]\n",
-    "        k_layer_head = k_layer[head//4]  # Every 4 heads share one key weight, [8x128x4096] -> [128x4096]\n",
-    "        v_layer_head = v_layer[head//4]  # Every 4 heads share one value weight, [8x128x4096] -> [128x4096]\n",
+    "        k_layer_head = k_layer[head//(n_heads // n_kv_heads)]  # Every 4 heads share one key weight, [8x128x4096] -> [128x4096]\n",
+    "        v_layer_head = v_layer[head//(n_heads // n_kv_heads)]  # Every 4 heads share one value weight, [8x128x4096] -> [128x4096]\n",
     "        \n",
     "        # Calculate XW to obtain the QKV vectors\n",
     "        # [17x4096] x [4096x128] = [17x128]\n",
@@ -2720,7 +2830,7 @@
     "        k_per_token_rotated = k_per_token_split_into_pairs_rotated.view(k_per_token.shape)  # Convert the result back to the original vector shape to obtain the final key vector. [17x64x2] -> [17x128]\n",
     "        \n",
     "        # Calculate the attention scores and normalize the scores simultaneously (i.e., Q×K/sqrt(dim))\n",
-    "        qk_per_token = torch.matmul(q_per_token_rotated, k_per_token_rotated.T)/(128)**0.5  # [17x128] x [128x17] = [17x17]\n",
+    "        qk_per_token = torch.matmul(q_per_token_rotated, k_per_token_rotated.T)/(head_dim)**0.5  # [17x128] x [128x17] = [17x17]\n",
     "        \n",
     "        # Mask the scores of future tokens\n",
     "        mask = torch.full(qk_per_token.shape, float(\"-inf\"), device=qk_per_token.device)  # Create a matrix with the same shape as the attention scores, filled with negative infinity, and stored in the same device as other vectors to prevent errors in subsequent calculations. [17x17]\n",

--- a/Deepdive-llama3-from-scratch-zh.ipynb
+++ b/Deepdive-llama3-from-scratch-zh.ipynb
@@ -102,7 +102,125 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 如果在 Google Colab 运行此单元格，请安装所需的库\n",
+    "# ! pip install tiktoken blobfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 导入相关库\n",
+    "from pathlib import Path  # 用于从文件路径中获取文件名/模型名\n",
+    "import tiktoken  # openai开发的开源库，用于文本编解码（文本和tokenid的相互转换）\n",
+    "from tiktoken.load import load_tiktoken_bpe  # 加载BPE模型\n",
+    "import torch  # 用于搭建模型和矩阵计算\n",
+    "import json  # 用于加载配置文件\n",
+    "import matplotlib.pyplot as plt  # 用于绘图\n",
+    "from huggingface_hub import login, hf_hub_download  # 使我们可以从 HuggingFace 下载权重"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 登录 HuggingFace，以便我们可以下载权重\n",
+    "login()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "print(f\"使用设备: {device}\")\n",
+    "torch.set_default_device(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 注意：要从 HuggingFace 获取权重，您需要访问模型的 URL 并请求访问权限。\n",
+    "# 例如，对于模型 Meta-Llama-3-8B，您需要访问 https://huggingface.co/meta-llama/Meta-Llama-3-8B\n",
+    "# 并请求被授予访问权限。\n",
+    "\n",
+    "# 选择任何版本或变体的 Llama。\n",
+    "# 您可以选择 3.0、3.1 或 3.2 版本。\n",
+    "# 3.2 版本提供 3B 或 1B 参数大小。\n",
+    "# 您还可以选择 \"Instruct\" 版本。\n",
+    "\n",
+    "# \"Instruct\" 版本与普通版本有什么区别？\n",
+    "# \"Vanilla\"（普通版）是尚未对齐的 \"基础模型\"。\n",
+    "# \"Instruct\" 版本经过对齐，并且能够回答问题。\n",
+    "# 代码是相同的，唯一的区别是权重的不同，这对学习来说很有意义。\n",
+    "\n",
+    "# model_path = \"Meta-Llama-3-8B\"             # https://huggingface.co/meta-llama/Meta-Llama-3-8B\n",
+    "\n",
+    "# model_path = \"Llama-3.1-8B\"                # https://huggingface.co/meta-llama/Llama-3.1-8B\n",
+    "\n",
+    "# model_path = \"Llama-3.2-3B\"                # https://huggingface.co/meta-llama/Llama-3.2-3B\n",
+    "model_path = \"Llama-3.2-1B\"                  # https://huggingface.co/meta-llama/Llama-3.2-1B\n",
+    "\n",
+    "# model_path = \"Meta-Llama-3-8B-Instruct\"    # https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct\n",
+    "\n",
+    "# model_path = \"Llama-3.1-8B-Instruct\"       # https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct\n",
+    "\n",
+    "# model_path = \"Llama-3.2-3B-Instruct\"       # https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct\n",
+    "# model_path = \"Llama-3.2-1B-Instruct\"       # https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo_id = f\"meta-llama/{model_path}\"\n",
+    "\n",
+    "files = [\n",
+    "    \"original/consolidated.00.pth\",   # PyTorch 格式的模型权重\n",
+    "    \"original/params.json\",           # 模型配置\n",
+    "    \"original/tokenizer.model\",       # 分词器模型\n",
+    "]\n",
+    "\n",
+    "for file in files:\n",
+    "    file_path = hf_hub_download(\n",
+    "        repo_id=repo_id,\n",
+    "        filename=file,\n",
+    "        local_dir=f\"./{model_path}\",\n",
+    "        use_auth_token=True\n",
+    "    )\n",
+    "    print(f\"已下载 {file} 到 {file_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 此时，我们需要确保 model_path 目录中包含以下 3 个文件：\n",
+    "assert Path(f\"{model_path}/original/tokenizer.model\").exists()\n",
+    "assert Path(f'{model_path}/original/consolidated.00.pth').exists()\n",
+    "assert Path(f\"{model_path}/original/params.json\").exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "ExecutionIndicator": {
      "show": false
@@ -132,16 +250,7 @@
    "source": [
     "# 加载基于BPE的tokenizer\n",
     "\n",
-    "# 导入相关库\n",
-    "from pathlib import Path  # 用于从文件路径中获取文件名/模型名\n",
-    "import tiktoken  # openai开发的开源库，用于文本编解码（文本和tokenid的相互转换）\n",
-    "from tiktoken.load import load_tiktoken_bpe  # 加载BPE模型\n",
-    "import torch  # 用于搭建模型和矩阵计算\n",
-    "import json  # 用于加载配置文件\n",
-    "import matplotlib.pyplot as plt  # 用于绘图\n",
-    "\n",
-    "\n",
-    "tokenizer_path = \"Meta-Llama-3-8B/original/tokenizer.model\"  # 分词器模型的路径\n",
+    "tokenizer_path = f\"{model_path}/original/tokenizer.model\"  # 分词器模型的路径\n",
     "\n",
     "# 常规词典外的特殊token\n",
     "# 在\"Meta-Llama-3-8B/\"路径下的'tokenizer.json'和'tokenizer_config.json'的added_tokens字段下都有这些特殊token\n",
@@ -282,7 +391,7 @@
    ],
    "source": [
     "# 加载模型，一个网络层名称-tensor类型参数的字典\n",
-    "model = torch.load(\"Meta-Llama-3-8B/original/consolidated.00.pth\")\n",
+    "model = torch.load(f\"{model_path}/original/consolidated.00.pth\", weights_only=False, map_location=device)\n",
     "\n",
     "# 输出前20层网络名，验证是否正确加载\n",
     "print(json.dumps(list(model.keys())[:20], indent=4))"
@@ -326,7 +435,7 @@
    ],
    "source": [
     "# 加载配置文件，每个配置的具体含义见下节\n",
-    "with open(\"Meta-Llama-3-8B/original/params.json\", \"r\") as f:\n",
+    "with open(f\"{model_path}/original/params.json\", \"r\") as f:\n",
     "    config = json.load(f)\n",
     "config"
    ]
@@ -1310,7 +1419,8 @@
    "source": [
     "# 计算θ，第一步，得到 i/D\n",
     "# [64]\n",
-    "zero_to_one_split_into_64_parts = torch.tensor(range(64))/64  # 每个特征分割后具有64个维度对，因此需要64个θ值\n",
+    "n_split = head_dim // 2\n",
+    "zero_to_one_split_into_64_parts = torch.tensor(range(n_split))/n_split  # 每个特征分割后具有64个维度对，因此需要64个θ值\n",
     "zero_to_one_split_into_64_parts"
    ]
   },
@@ -1438,6 +1548,7 @@
     "for i, index in enumerate(token_to_show):\n",
     "    value = freqs_cis[index]\n",
     "    for j, element in enumerate(value):\n",
+    "        element = element.cpu()\n",
     "        axs[i].plot([0, element.real], [0, element.imag], color='blue', linewidth=1, label=f\"Index: {j}\")  # 以实部为横坐标，虚部为纵坐标，绘制从原点到坐标点的蓝线\n",
     "        axs[i].annotate(f\"{j}\", xy=(element.real, element.imag), color='red')  # 绘制红色的数字注释，表示第i对维度\n",
     "    axs[i].set_xlabel('Real')\n",
@@ -2183,8 +2294,8 @@
     "for head in range(n_heads):\n",
     "    # 取出当前头对应的qkv权重矩阵\n",
     "    q_layer0_head = q_layer0[head]  # [32x128x4096] -> [128x4096]\n",
-    "    k_layer0_head = k_layer0[head//4]  # 每4个头共享一个key权重，[8x128x4096] -> [128x4096]\n",
-    "    v_layer0_head = v_layer0[head//4]  # 每4个头共享一个value权重，[8x128x4096] -> [128x4096]\n",
+    "    k_layer0_head = k_layer0[head//(n_heads // n_kv_heads)]  # 每4个头共享一个key权重，[8x128x4096] -> [128x4096]\n",
+    "    v_layer0_head = v_layer0[head//(n_heads // n_kv_heads)]  # 每4个头共享一个value权重，[8x128x4096] -> [128x4096]\n",
     "    \n",
     "    # 计算XW，得到qkv向量\n",
     "    # [17x4096] x [4096x128] = [17x128]\n",
@@ -2665,8 +2776,8 @@
     "    for head in range(n_heads):\n",
     "        # 取出当前头的qkv权重矩阵\n",
     "        q_layer_head = q_layer[head]  # [32x128x4096] -> [128x4096]\n",
-    "        k_layer_head = k_layer[head//4]  # 每4个头共享一个key权重，[8x128x4096] -> [128x4096]\n",
-    "        v_layer_head = v_layer[head//4]  # 每4个头共享一个value权重，[8x128x4096] -> [128x4096]\n",
+    "        k_layer_head = k_layer[head//(n_heads // n_kv_heads)]  # 每4个头共享一个key权重，[8x128x4096] -> [128x4096]\n",
+    "        v_layer_head = v_layer[head//(n_heads // n_kv_heads)]  # 每4个头共享一个value权重，[8x128x4096] -> [128x4096]\n",
     "        \n",
     "        # 计算XW，得到输入token的qkv向量\n",
     "        # [17x4096] x [4096x128] = [17x128]\n",
@@ -2689,7 +2800,7 @@
     "        k_per_token_rotated = k_per_token_split_into_pairs_rotated.view(k_per_token.shape)  # 结果还原回原始向量形状，得到最终的key向量，[17x64x2] -> [17x128]\n",
     "        \n",
     "        # 计算注意力分数，同时归一化分数（即QxK/sqrt(dim)）\n",
-    "        qk_per_token = torch.matmul(q_per_token_rotated, k_per_token_rotated.T)/(128)**0.5  # [17x128] x [128x17] = [17x17]\n",
+    "        qk_per_token = torch.matmul(q_per_token_rotated, k_per_token_rotated.T)/(head_dim)**0.5  # [17x128] x [128x17] = [17x17]\n",
     "        \n",
     "        # 屏蔽未来token的分数\n",
     "        mask = torch.full(qk_per_token.shape, float(\"-inf\"), device=qk_per_token.device)  # 创建和注意力分数相同形状，值全为负无穷的矩阵，并保证存储位置和其他向量一致，防止后续计算时错误，[17x17]\n",


### PR DESCRIPTION
@therealoliver Hi! I'm a big fan of your work (and naklecha’s). I really enjoyed this notebook—it was extremely helpful, and I appreciate how you've improved upon naklecha’s version.

I've made a few enhancements to make it even easier for newcomers to run on platforms like Google Colab. Additionally, I streamlined the process for downloading Llama weights from Hugging Face, so users don’t have to figure out where and how to get them.

Your notebook currently uses Llama 3, but I think it would be both useful and educational to allow users to easily switch between versions 3.1 and 3.2, including the Instruct variants.

Let me know if you’re open to these changes—if so, I’d be happy to apply them to the Chinese version as well.

Enhancements:
1. Enhances Google Colab compatibility by installing missing dependencies: tiktoken and blobfile.
2. Simplifies downloading Llama weights from Hugging Face.
3. Allows easy selection between Llama 3, 3.1, and 3.2 versions, including Instruct variants.
4. Enables execution on GPU when available.

Thanks for your great work!